### PR TITLE
Pull in branch where interpolation and running quilt in chunks replaced grid anchoring

### DIFF
--- a/bin/quilt/genoprobs.R
+++ b/bin/quilt/genoprobs.R
@@ -11,19 +11,18 @@
 
 library(data.table)
 library(dplyr)
-library(purrr)
 library(qtl2)
 
 # test_dir
-# test_dir <- "/flashscratch/widmas/QUILT/work/ea/265a9260b6142c01121836d52d5b62"
+# test_dir <- "/flashscratch/widmas/QUILT/work/7d/cb753ced9d455d4d96aa9388126158"
 # setwd(test_dir)
-# chrom <- "X"
+# chrom <- "1"
 # sample_genos <- list.files(pattern = "sample_geno")
 # founder_genos <- list.files(pattern = "founder_geno")
 # pmap <- list.files(pattern = "pmap")
 # gmap <- list.files(pattern = "gmap")
 # metadata <- "covar.csv"
-# cross_type <- "het3"
+# cross_type <- "do"
 
 # take arguments
 args <- commandArgs(trailingOnly = TRUE)
@@ -125,6 +124,12 @@ if(cross_type == "genail4" | cross_type == "het3"){
   print("Cross type specified does not have a process to make .json file; ending")
 }
 
+# test if any sample genotypes from the segment of the chromosome
+any_markers <- nrow(read.csv(sample_genos))
+if (any_markers == 0) {
+  message("No markers in chromosome segment, exiting.")
+  quit(save = "no", status = 0, runLast = FALSE)
+}
 
 # Load in the cross object
 cross <- qtl2::read_cross2(paste0("chr",chrom,"_control_file.json"))
@@ -136,29 +141,29 @@ cross <- qtl2::drop_nullmarkers(cross)
 pr <- qtl2::calc_genoprob(cross = cross, 
                           map = cross$pmap, 
                           error_prob = 0.002, 
-                          cores = (parallel::detectCores()/2), quiet = F)
-# Estimate genotyping errors
-pr_errorlod <- qtl2::calc_errorlod(cross = cross,
-                                   probs = pr, 
-                                   cores = (parallel::detectCores()/2))
+                          cores = (parallel::detectCores()/1.2), quiet = F)
+# # Estimate genotyping errors
+# pr_errorlod <- qtl2::calc_errorlod(cross = cross,
+#                                    probs = pr, 
+#                                    cores = (parallel::detectCores()/1.2))
 
-# number of animals with that genotype with an error LOD > 2
-genotyping_errors <- rowSums(t(pr_errorlod[[1]]) > 2)
-error_genotypes <- names(which(genotyping_errors != 0))
-print("How many potential genotyping errors?")
-print(paste0(length(error_genotypes), " potential genotyping errors"))
+# # number of animals with that genotype with an error LOD > 2
+# genotyping_errors <- rowSums(t(pr_errorlod[[1]]) > 2)
+# error_genotypes <- names(which(genotyping_errors != 0))
+# print("How many potential genotyping errors?")
+# print(paste0(length(error_genotypes), " potential genotyping errors"))
 
-# Remove bad genotypes
-corrected_cross <- drop_markers(cross, error_genotypes)
-cross <- corrected_cross
+# # Remove bad genotypes
+# corrected_cross <- drop_markers(cross, error_genotypes)
+# cross <- corrected_cross
 
-# Calculate new genotype probs with reduced map
-pr <- qtl2::calc_genoprob(cross = cross, 
-                          map = cross$pmap,
-                          error_prob = 0.002,
-                          cores = (parallel::detectCores()/2), quiet = F)
+# # Calculate new genotype probs with reduced map
+# pr <- qtl2::calc_genoprob(cross = cross, 
+#                           map = cross$pmap,
+#                           error_prob = 0.002,
+#                           cores = (parallel::detectCores()/1.2), quiet = F)
 # Calculate allele probs
-# apr <- qtl2::genoprob_to_alleleprob(probs = pr,cores = (parallel::detectCores()/2), quiet = F)
+# apr <- qtl2::genoprob_to_alleleprob(probs = pr,cores = (parallel::detectCores()/1.2), quiet = F)
 
 # Save objects
 save(cross, file = paste0("chr_",chrom,"_cross.RData"))

--- a/bin/quilt/get_hap_blocks.R
+++ b/bin/quilt/get_hap_blocks.R
@@ -1,0 +1,243 @@
+################################################################################
+# This script contains code to estimate haplotype blocks in the DO using the
+# 36-state genoprobs. It does this by crawling along the probabilities,
+# looking for markers which are highly correlated with the current marker.
+# The first marker to show low correlation with the current marker is taken
+# to be the end of one haplotype block.
+# The first function estimates haplotype blocks for ONE SAMPLE on ONE
+# CHROMOSOME.
+# The second function accepts a qtl2-style genoprobs object and at qtl2-style
+# marker map and estimates the haplotype blocks for all samples on all 
+# chromosomes.
+# The functions are currently SLOW.
+# 
+# Daniel Gatti
+# dan.gatti@jax.org
+# 2025-01-16
+
+##########
+# Estimate the haplotype blocks for ONE SAMPLE on ONE CHROMOSOME.
+# This function crawls along the probability correlation matrix and
+# searches for haplotype blocks by finding markers which are highly
+# correlated with the first marker in the block. 
+# Arguments:
+# probs: numeric matrix containing the 36-state genoprobs for
+#        one sample on one chromosome. Genotype states in rows
+#        and markers in columns. Dimensions must have dimnames.
+# mkrs: numeric vector containing the marker positions for the
+#       markers in probs. Must be named. Markers must already 
+#       be in the same order as probs.
+# cor_thr: numeric value indicating the correlation with the proximal 
+#          genoprobs at which the end of a hplotype block will be called. 
+#          Default = 0.5. 
+# alt_prob_thr: numeric value indicating the mean block probability below which
+#               alternate genotypes will be listed. Default = 0.9.
+#
+# Returns: data.frame with one row per haplotype block containing:
+#   prox_marker: character string containing the proximal marker.
+#   dist_marker: character string containing the distal marker.
+#   prox_pos: numeric value containing the proximal marker position.
+#   dist_pos: numeric value containing the distal marker position.
+#   gt: character string containing the genotype with the highest probability.
+#   mean_prob: numeric value containing the mean block probability for the 
+#              genotype in "gt".
+#   prox_idx: numeric value containing the proximal marker index.
+#   dist_idx: numeric value containing the distal marker index.
+#   alt_gt: charater string containing other genotype with high probabilities.
+#           Each genotype separated by a ":".
+#   alt_prob: numeric values containing the mean block probability for the
+#             alternate strains listed in "alt_gt". Values separated by ":".
+get_blocks_1sample = function(probs, mkrs, cor_thr = 0.5, alt_prob_thr = 0.9) {
+
+  states  = rownames(probs)
+  markers = colnames(probs)
+
+  n_blocks = 2000
+  blocks = data.frame(prox_marker = rep('', n_blocks),
+                      dist_marker = rep('', n_blocks),
+                      prox_pos    = rep(0,  n_blocks),
+                      dist_pos    = rep(0,  n_blocks),
+                      gt          = rep('', n_blocks),
+                      mean_prob   = rep(0,  n_blocks),
+                      prox_idx    = rep(0,  n_blocks),
+                      dist_idx    = rep(0,  n_blocks),
+                      alt_gt      = rep(NA, n_blocks),
+                      alt_prob    = rep(NA, n_blocks))
+  
+  block_idx = 1
+  prox_idx  = 1
+  dist_idx  = 1
+
+  # While the proximal index is less than the number of markers.
+  while(prox_idx < length(markers)) {
+  
+    # Set the search range from the current marker to the end of the
+    # chromosome.
+    search_range = prox_idx:length(markers)
+    
+    # Get the correlation of the current marker with all distal markers.
+    probs_cor = cor(probs[,prox_idx], probs[,search_range])[1,]
+    
+    # Find the distal end of the haplotype block by searching for the
+    # first marker that has low correlation with the proximal marker.
+    wh = which(probs_cor < cor_thr)
+    
+    # This may happen at the end of the chromosome.
+    if(length(wh) == 0) {
+    
+      dist_idx = length(markers)
+
+    } else {
+    
+      dist_idx = min(wh) + prox_idx - 2
+
+    } # else
+
+    # If we have a one marker block, skip over it. Otherwise,
+    # process the block. 
+    if(prox_idx != dist_idx) {
+  
+      # Set the proximal and distal marker names.
+      blocks$prox_marker[block_idx] = markers[prox_idx]
+      blocks$dist_marker[block_idx] = markers[dist_idx]
+    
+      # Get the mean probability for each genotype state.
+      rm_probs = rowMeans(probs[,prox_idx:dist_idx])
+      
+      # Set the called genotype to the state with the highest probability.
+      blocks$gt[block_idx] = names(which.max(rm_probs))
+      
+      # Get the mean probability for the maximal state.
+      blocks$mean_prob[block_idx] = max(rm_probs)
+    
+      # Set the proximal and distal marker indices.
+      blocks$prox_idx[block_idx] = prox_idx
+      blocks$dist_idx[block_idx] = dist_idx
+
+      # Set the proximan and distal marker positions.
+      blocks$prox_pos[block_idx] = mkrs[prox_idx]
+      blocks$dist_pos[block_idx] = mkrs[dist_idx]
+      
+      # Determine whethere we need to include alternate genotypes by
+      # seeing whether the mean block probability is over alt_prob_thr.
+      rm_probs = sort(rm_probs, decreasing = TRUE)
+      # Get the cumulative sum of the genotype probs.
+      # We use this to determine whether we should report more than one
+      # genotype.
+      cs_probs = cumsum(rm_probs)
+
+      num_gt = min(which(cs_probs >= alt_prob_thr))
+      if(num_gt > 1) {
+      
+        # Add alternate genotypes.
+        alt_rng = 2:num_gt
+        
+        blocks$alt_gt[block_idx] = paste(names(rm_probs)[alt_rng], 
+                                         collapse = ';')
+        blocks$alt_prob[block_idx] = paste(round(rm_probs[alt_rng], digits = 4), 
+                                           collapse = ';')
+      
+      } # if(num_gt > 1)
+
+      # Increment block index.
+      block_idx = block_idx + 1
+    
+    } # if(prox_idx != dist_idx)
+    
+    # Increment proximal index for the next block.
+    prox_idx  = dist_idx  + 1
+
+  } # while(prox_idx < ncol(probs))
+
+  # Trim down the blocks since we started with 1000.
+  blocks = subset(blocks, prox_marker != '')
+  rownames(blocks) = NULL
+  
+  return(blocks)
+
+} # get_blocks_1sample()
+
+
+##########
+# This function estimates the haplotype blocks in the DO for all samples
+# on all chromosomes.
+# Arguments:
+# probs: list which is a qtl2-style genoprobs object. Each list element
+#        is a 3-dimensional array with samples in rows, 36 genotype states
+#        in columns, and markers in slices. All dimensions must have dimnames.
+#        The list element names are chromosomes. Marker names must match 
+#        those in "map".
+# map: list which is a qtl2-style marker map. Each list element is a numeric
+#      vector containing marker positions in Mb. The vector names must be
+#      marker names. The list element names are chromosomes. Marker names
+#      must match those in "probs".
+# cor_thr: numeric value indicating the correlation with the proximal 
+#          genoprobs at which the end of a hplotype block will be called. 
+#          Default = 0.5. 
+# alt_prob_thr: numeric value indicating the mean block probability below which
+#               alternate genotypes will be listed. Default = 0.9.
+# NOTE: I tried to parallelize this with foreach and doParallel, but the
+# workers couldn't find the get_blocks_1sample() function even though it
+# was in the environment when I called %dopar%.
+get_hap_blocks = function(probs, map, cor_thr = 0.5, alt_prob_thr = 0.9) {
+
+  # Verify that probs and map have the same length.
+  if(length(probs) != length(map)) {
+    stop(paste0('get_hap_blocks: probs (', length(probs), ') and map (',
+         length(map), ') must have the same length.'))
+  } # if(length(probs) != length(map)
+
+  # Verify that probs and map have the same chromsome names.
+  if(!all(names(probs) == names(map))) {
+    stop(paste0('get_hap_blocks: probs and map must have the same chromosome ',
+         'names in the same order.'))
+  } # if(!all(names(probs) == names(map)))
+
+  # Verify that we have a 36-state genoprobs object.
+  if(ncol(probs[[1]]) != 36) {
+    stop('get_hap_blocks: This function only works with the 36-state genoprobs.')
+  } # if(ncol(probs[[1]]) != 36)
+
+  # Verify that the markers are the same between probs and map.
+  for(chr in seq_along(probs)) {
+
+    if(!all(names(map[[chr]]) == dimnames(probs[[chr]])[[3]])) {
+      stop(paste0('get_hap_blocks: Markers do not match between probs and map',
+                  ' on chromosome', names(map)[chr]))
+    } # if(!all(names(map[[chr]]) == dimnames(probs[[chr]])[[3]]))
+
+  } # for(chr)
+
+  # Estimate haplotype blocks for all samples on all chromosomes.
+  hap_blocks = setNames(vector('list', length(probs)), names(probs))
+
+  for(chr in seq_along(probs)) {
+
+    t1 = proc.time()
+    message(paste('CHR:', chr))
+
+    for(sample in 1:nrow(probs[[chr]])) {
+
+      sample_blocks = get_blocks_1sample(probs[[chr]][sample,,], map[[chr]], 
+                                         cor_thr, alt_prob_thr)
+      sample_blocks = cbind(id  = rownames(probs[[chr]])[sample], 
+                            chr = chr, 
+                            sample_blocks)
+
+      hap_blocks[[chr]] = rbind(hap_blocks[[chr]], sample_blocks)
+
+    } # for(sample)
+
+    message(proc.time()[3] - t1[3])
+
+  } # for(chr)
+
+  # Combine the haplotype blocks from all chromosomes.
+  hap_blocks           = do.call(rbind, hap_blocks)
+  rownames(hap_blocks) = NULL
+  
+  return(hap_blocks)
+
+} # get_hap_blocks()
+
+

--- a/bin/quilt/interpolate_genoprobs.R
+++ b/bin/quilt/interpolate_genoprobs.R
@@ -1,0 +1,111 @@
+################################################################################
+# Given two sets of genotype probabilities and thier marker postions,
+# interpolate the probabilities of the first set to the second set.
+# Daniel Gatti
+# dan.gatti@jax.org
+# 2022-09-08
+################################################################################
+
+library(IRanges)
+library(qtl2convert)
+library(qtl2)
+
+# Interpolate pr1 onto the positions of mkr2.
+# Arguments:
+# pr1: 3D numeric array of genoprobs with samples in rows, founders in columns, 
+#      & markers in slices.
+# mkr1: Named numeric vector of marker position (in bp) in pr1.
+# mkr2: Names numeric vector of marker positions (in bp) to interpolate genoprobs to.
+interpolate_one_chr = function(pr1, mkr1, mkr2) {
+  
+  # Convert markers to IRanges to used inter-range functions.
+  mkr1 = IRanges(start = mkr1, width = 1, names = names(mkr1))
+  mkr2 = IRanges(start = mkr2, width = 1, names = names(mkr2))
+  
+  # The the proximal and distal markers in mkr1 which bracket the markers
+  # in mkr2.
+  proximal = follow(mkr2,  mkr1)
+  distal   = precede(mkr2, mkr1)
+  
+  proximal[is.na(proximal)] = 1
+  distal[is.na(distal)]     = length(mkr1)
+  
+  # Get the proximal and distal probs.
+  prox_pr = pr1[,,proximal]
+  dist_pr = pr1[,,distal]
+  
+  mkr_interp = (start(mkr2) - start(mkr1)[proximal]) / (start(mkr1)[distal] - start(mkr1)[proximal])
+  mkr_interp[is.infinite(mkr_interp)] = 1
+  mkr_interp = array(rep(mkr_interp, each = nrow(pr1) * ncol(pr1)), 
+                     c(nrow(pr1), ncol(pr1), length(mkr2)), 
+                     dimnames = list(rownames(pr1), colnames(pr1), names(mkr2)))
+  
+  # Create the new probs array.
+  tmp = prox_pr + (mkr_interp) * (dist_pr - prox_pr)
+  dimnames(tmp)[[3]] = names(mkr2)
+  return(tmp)
+  
+} # interpolate_one_chr()
+
+
+# Top-level interpolate function.
+# Arguments:
+# probs1: qtl2-style genoprobs. Named list containing 3D numerical arrays with
+#         samples in rows, founders in columns, and markers in slices. Each
+#         list element contains one chromosome and names contain chromosome name. 
+# markers1: qtl2-style marker map. Named list containing a named numeric 
+#           vector of marker positions for one chromosome. Names of vector 
+#           are markers in probs1. Each list element contains one chromosome 
+#           and names contain chromosome name.
+# markers2: qtl2-style marker map. Named list containing a named numeric 
+#           vector of marker positions for one chromosome. Names of vector 
+#           are new markers to interpolate to. Each list element contains one 
+#           chromosome and names contain chromosome name. probs1 will be 
+#           interpolated onto the markers in this map.
+interpolate_genoprobs = function(probs1, markers1, markers2) {
+
+  # Perform some minimal error checking. 
+  # TBD: More rigorous checks for matching chromosome names in each object.
+  if(length(probs1) != length(markers1)) {
+    stop('Probs1 and markers1 must be the same length.')
+  }
+
+  # If the marker maps are in Mb, convert to bp.
+  # Chr 1 is the longest chromsome and it is less than 200 Mb.
+  if(max(unlist(markers1) < 200)) {
+
+    markers1 = lapply(markers1, '*', 1e6)
+
+  } # if(max(unlist(markers1) < 200))
+
+  if(max(unlist(markers2) < 200)) {
+
+    markers2 = lapply(markers2, '*', 1e6)
+
+  } # if(max(unlist(markers2) < 200))  
+  
+  all_chr = names(probs1)
+
+  new_probs1        = vector('list', length(probs1))
+  names(new_probs1) = names(probs1)
+
+  for(chr in all_chr) {
+      
+    new_probs1[[chr]] = interpolate_one_chr(pr1  = probs1[[chr]],
+                                            mkr1 = markers1[[chr]],
+                                            mkr2 = markers2[[chr]])
+    
+  } # for(chr)
+
+  # Set the attributes for the probs object.
+  attr(new_probs1, 'crosstype')    = attr(probs1, 'crosstype')
+  attr(new_probs1, 'is_x_chr')     = attr(probs1, 'is_x_chr')
+  attr(new_probs1, 'alleles')      = attr(probs1, 'alleles')
+  attr(new_probs1, 'alleleprobs')  = attr(probs1, 'alleleprobs')
+  class(new_probs1)                = class(probs1)
+  
+  return(new_probs1)
+  
+} # interpolate_genoprobs()
+
+

--- a/bin/quilt/interpolate_quilt_genoprobs.R
+++ b/bin/quilt/interpolate_quilt_genoprobs.R
@@ -1,0 +1,77 @@
+#!/usr/bin/env Rscript
+
+################################################################################
+# Interpolate QUILT genotype probabilities to specified gridfile.
+#
+# Sam Widmayer
+# samuel.widmayer@jax.orgs
+# 20250221
+################################################################################
+
+library(qtl2)
+library(tidyr)
+library(dplyr)
+
+# take arguments
+args <- commandArgs(trailingOnly = TRUE)
+
+# what chromosome?
+chrom <- args[1]
+
+# ranges
+start <- args[2]
+stop <- args[3]
+
+# qtl2 files
+pr_file <- args[4]
+cross_file <- args[5]
+
+# grid file
+gridfile <- args[6]
+
+# source Gatti interpolation script
+source(args[7])
+
+## testing
+# test_dir <- "/flashscratch/widmas/QUILT/work/c6/b1acb8cd3ffa61aa16c8329bf4345d"
+# setwd(test_dir)
+# chrom <- strsplit(list.files(pattern = "cross"),"_")[[1]][[2]]
+# start <- "3050143"
+# stop <- "9999939"
+# # 
+# # qtl2 files
+# pr_file <- list.files(pattern = "probs")
+# cross_file <- list.files(pattern = "cross.RData")
+# 
+# grid file
+# gridfile <- "/projects/compsci/vmp/USERS/widmas/quilt-nf/data/interp_1M_physical_grid.csv"
+# source("/projects/compsci/vmp/USERS/widmas/quilt-nf/bin/quilt/interpolate_genoprobs.R")
+
+### RUN ###
+
+# load probs
+load(pr_file)
+
+# load cross
+load(cross_file)
+
+# load grid
+grid <- read.csv(gridfile)
+reduced_grid <- grid %>%
+  dplyr::filter(chr == chrom,
+                pos > min(cross$pmap[[chrom]]),
+                pos < max(cross$pmap[[chrom]]))
+
+# make map
+grid_map <- reduced_grid$pos
+names(grid_map) <- reduced_grid$marker
+
+# interpolate
+int_pr <- interpolate_one_chr(pr1 = pr[[chrom]], # original resolution
+                              mkr1 = cross$pmap[[chrom]]*1e6, # original map
+                              mkr2 = grid_map*1e6) # interpolated probs
+saveRDS(object = int_pr, file = paste0("int_",start,"_",stop,"_pr.rds"))
+saveRDS(object = grid_map, file = paste0("int_",start,"_",stop,"_map.rds"))
+saveRDS(object = cross, file = paste0("original_",start,"_",stop,"_cross.rds"))
+
+

--- a/bin/quilt/merge_chrom_probs.R
+++ b/bin/quilt/merge_chrom_probs.R
@@ -1,0 +1,75 @@
+#!/usr/bin/env Rscript
+
+################################################################################
+# Merge QUILT genotype probabilities from the same chromosome.
+#
+# Sam Widmayer
+# samuel.widmayer@jax.org
+# 20250221
+################################################################################
+
+library(qtl2)
+library(tidyr)
+library(dplyr)
+
+# take arguments
+args <- commandArgs(trailingOnly = TRUE)
+
+# what chromosome?
+chrom <- args[1]
+
+# genoprob files
+pr_files <- list.files(pattern = "pr.rds")
+
+## testing
+# test_dir <- "/flashscratch/widmas/QUILT/work/c5/ffbb6a9eff59098539c6f0c930dabe"
+# setwd(test_dir)
+# chrom <- "1"
+# pr_files <- list.files(pattern = "pr.rds")
+
+### RUN ###
+
+# read in probs
+probs_list <- vector("list",length(pr_files))
+for(i in 1:length(pr_files)){
+  message(pr_files[[i]])
+  p <- readRDS(pr_files[[i]])
+  probs_list[[i]] <- p
+}
+
+# Get the depth of the new probs object
+array_depth <- sum(unlist(lapply(probs_list, function(x) dim(x)[[3]])))
+# Make empty probs object
+combined_probs <- array(dim = c(dim(probs_list[[1]])[1], dim(probs_list[[1]])[2], array_depth))
+dimnames(combined_probs)[[1]] <- dimnames(probs_list[[1]])[[1]]
+dimnames(combined_probs)[[2]] <- dimnames(probs_list[[1]])[[2]]
+dimnames(combined_probs)[[3]] <- unlist(lapply(probs_list, function(x) dimnames(x)[[3]]))
+# put probs in the right spots with marker names
+marker_names <- list()
+for(i in 1:length(probs_list)){
+  # ind <- new_indices[[i]]
+  # message(i)
+  # ind <- seq(ind[1], ind[2])
+  p <- probs_list[[i]]
+  combined_probs[,,dimnames(p)[[3]]] <- p
+  # for(j in 1:length(ind)){
+  #   combined_probs[,,ind[j]] <- p[,,j]
+  # }
+  marker_names[[i]] <- dimnames(p)[[3]]
+}
+
+# read in marker maps
+map_files <- list.files(pattern = "map.rds")
+pmap <- unlist(lapply(map_files, readRDS))
+pmap <- sort(pmap)
+
+# sort the genoprobs
+sorted_combined_probs <- combined_probs[,,names(pmap)]
+
+# write objects
+saveRDS(object = sorted_combined_probs, file = paste0("chr",chrom,"_genoprobs.rds"))
+saveRDS(object = pmap, file = paste0("chr",chrom,"_pmap.rds"))
+
+
+
+

--- a/bin/quilt/prepare_qtl2_files.R
+++ b/bin/quilt/prepare_qtl2_files.R
@@ -4,14 +4,16 @@
 #
 # Sam Widmayer
 # samuel.widmayer@jax.org
-# 2025-01-17
+# 2025-02-11
 ################################################################################
 
 # library(readxl)
-library(VariantAnnotation)
+# library(VariantAnnotation)
 library(qtl2convert)
 library(qtl2)
 library(stringr)
+library(tidyr)
+library(dplyr)
 
 
 ##### VARIABLES #####
@@ -21,7 +23,6 @@ library(stringr)
 # sample_file:  path to sample VCF produced by QUILT.
 # meta_file:    path to sample metadata file.
 # marker_file:  path to QUILT marker file with bp and cM values.
-# qtl2_dir:     path to qtl2 output directory where files will be written.
 # cross_type:   cross type according to wrt qtl2 preferences
 
 args = commandArgs(trailingOnly = TRUE)
@@ -44,35 +45,31 @@ marker_file = args[5]
 # Chromosome
 chr = args[6]
 
-# Grid file
-grid_file = '/projects/compsci/vmp/USERS/widmas/quilt-nf/data/quilt_1M_physical_grid.csv'
-
-
 ##### TROUBLESHOOTING FILES #####
-# Founder genotypes and marker positions
-# founder_file = '/projects/compsci/vmp/USERS/widmas/quilt-nf/reference_data/het3/chrX_phased_snps.vcf.gz'
-
-# Sample genotypes from QUILT.
-# sample_file = "/projects/korstanje-lab/Pureplex/TumorStudy/results/quilt/20250110_tumorstudy_run2/10/10000/quilt_vcfs/quilt.X.vcf.gz"
-
-# Sample metadata file.
-# meta_file = '/projects/korstanje-lab/Pureplex/TumorStudy/metadata/korstanje_het3_covar_genail4.csv'
-
-# Cross type
-# cross_type = 'het3'
-
-# Marker map.
-# marker_file = '/projects/compsci/vmp/USERS/widmas/quilt-nf/reference_data/het3/chrX_gen_map.txt'
-
-# chromosome
-# chr = "X"
+# # Founder genotypes and marker positions
+# founder_file = '/projects/compsci/vmp/USERS/widmas/quilt-nf/chr19_fg.txt'
+# 
+# # Sample genotypes from QUILT.
+# sample_file = "/projects/compsci/vmp/USERS/widmas/quilt-nf/chr19_sg.txt"
+# 
+# # Sample metadata file.
+# meta_file = '/projects/compsci/vmp/USERS/widmas/quilt-nf/data/DO_covar.csv'
+# 
+# # Cross type
+# cross_type = 'do'
+# 
+# # Marker map.
+# marker_file = '/projects/compsci/vmp/USERS/widmas/quilt-nf/reference_data/do/chr19_gen_map.txt'
+# 
+# # chromosome
+# chr = "19"
 
 
 
 
 ##### MAIN #####
 
-# dir.create(qtl2_dir, showWarnings = FALSE)
+
 message("Read in metadata")
 meta <- read.csv(meta_file)
 
@@ -82,54 +79,40 @@ meta <- meta[which(!duplicated(meta$id)),]
 # can't have any missing values in the covariate file and/or cross info columns
 meta <- meta[complete.cases(meta),]
 
-message("Read in founder genotypes")
 # Read in founder genotypes.
-founder_vcf = readVcf(founder_file, 'grcm39')
-founder_vcf = genotypeCodesToNucleotides(founder_vcf)
-founder_gt  = geno(founder_vcf)$GT
-founder_gt  = sub('\\|', '', founder_gt)
+message("Read in founder genotypes")
+founder_gt = read.delim(founder_file, check.names = F)
+fg_mkrs = paste(founder_gt$CHROM,founder_gt$POS,founder_gt$REF,founder_gt$ALT, sep = "_")
+rownames(founder_gt) <- fg_mkrs
 quilt_variants <- nrow(founder_gt)
-rownames(founder_gt) = gsub("[^A-Za-z0-9_]", "_", rownames(founder_gt))
-head(rownames(founder_gt))
 
-message("Getting founder marker positions")
-# Get the marker positions for the founders.
-founder_rr = rowRanges(founder_vcf)
-names(founder_rr) = gsub("[^A-Za-z0-9_]", "_", names(founder_rr))
-# head(founder_rr)
-rm(founder_vcf)
-
-message("Transposing to grid positions")
-grid <- read.csv(grid_file)
-grid <- grid[grid$chr == chr,]
-grid_gr <- GRanges(seqnames = grid$chr,
-                   ranges = IRanges(start = grid$pos*1e6, end = grid$pos*1e6))
-grid_nearest <- nearest(grid_gr, founder_rr)
-grid_nearest <- unique(grid_nearest)
-founder_rr <- founder_rr[grid_nearest,]
-
+# Read sample genotypes
 message("Reading in sample genotypes")
-# Read in sample genotypes.
-sample_vcf = readVcf(sample_file, 'grcm39', founder_rr)
-sample_vcf = genotypeCodesToNucleotides(sample_vcf)
-sample_vcf_info = info(sample_vcf)
-rownames(sample_vcf_info) = gsub("[^A-Za-z0-9_]", "_", rownames(sample_vcf_info))
-
-# isolate sample genotypes
-sample_gt  = geno(sample_vcf)$GT
-sample_gt  = sub('\\|', '', sample_gt)
+sample_gt <- read.delim(sample_file, check.names = F)
+sg_mkrs = paste(sample_gt$CHROM,sample_gt$POS,sample_gt$REF,sample_gt$ALT, sep = "_")
+rownames(sample_gt) <- sg_mkrs
+stopifnot(rownames(sample_gt) == rownames(founder_gt))
 stopifnot("id" %in% colnames(meta))
 covar_sample_inds <- c()
 
+# get metadata
+sample_gt_meta <- sample_gt %>%
+  dplyr::select(CHROM, POS, REF, ALT, HWE, INFO_SCORE)
+
+# get genos to fix names
+sample_gt_genos <- sample_gt %>%
+  dplyr::select(-c(CHROM, POS, REF, ALT, HWE, INFO_SCORE))
+stopifnot(rownames(sample_gt_meta) == rownames(sample_gt_genos))
+
 # attempt a clean join; this is only possible when exact sample names are known
-if(!all(meta$id %in% colnames(sample_gt)) && !all(colnames(sample_gt) %in% meta$id)){
+if(!all(meta$id %in% colnames(sample_gt_genos)) && !all(colnames(sample_gt_genos) %in% meta$id)){
   
   message("At least one sample name as supplied in metadata doesn't match sequencing data.")
   message("Searching sample genotypes for metadata sample names...")
   
   # link the sample IDs
   # assuming that the covar file has some element of the library name in it
-  covar_sample_ids <- lapply(colnames(sample_gt), function(x){
+  covar_sample_ids <- lapply(colnames(sample_gt_genos), function(x){
     
     # try a symbol split
     first_split <- stringr::str_split(string = x, pattern = "[:punct:]")[[1]]
@@ -174,88 +157,91 @@ if(!all(meta$id %in% colnames(sample_gt)) && !all(colnames(sample_gt) %in% meta$
   quilt_samples_absent_from_meta <- unlist(lapply(covar_sample_ids, is.null))
   if(any(quilt_samples_absent_from_meta)){
     covar_sample_ids <- covar_sample_ids[-which(quilt_samples_absent_from_meta)]
-    sample_gt <- sample_gt[,-which(quilt_samples_absent_from_meta)]
+    sample_gt_genos <- sample_gt_genos[,-which(quilt_samples_absent_from_meta)]
   }
   # assign the sample names from the metadata present in both files to the sample genotypes
-  colnames(sample_gt) <- unlist(covar_sample_ids)
+  colnames(sample_gt_genos) <- unlist(covar_sample_ids)
   
 } else {
   message("All sample names as supplied in metadata match sequencing data.")
-  sample_gt <- sample_gt
+  sample_gt_genos <- sample_gt_genos
 }
 
+# bind things back together
+sample_gt_renamed <- cbind(sample_gt_meta, sample_gt_genos)
+
+# recode sample genotypes
+recoded_sample_genos <- apply(sample_gt_renamed, 1, function(x){
+  REF = x[3]
+  ALT = x[4]
+  g = as.numeric(gsub(pattern = "[|]",replacement = "",x[-c(1:6)]))
+  g[g == 0] <- paste0(REF,REF)
+  g[g == 11] <- paste0(ALT,ALT)
+  g[g %in% c(10,1)] <- paste0(REF, ALT)
+  return(g)
+})
+recoded_sample_genos <- t(recoded_sample_genos)
+colnames(recoded_sample_genos) <- colnames(sample_gt_genos)
+sample_gt_renamed <- cbind(sample_gt_meta, recoded_sample_genos)
+
+# recode founder genotypes
+recoded_founder_genos <- apply(founder_gt, 1, function(x){
+  REF = x[3]
+  ALT = x[4]
+  g = as.numeric(gsub(pattern = "[|]",replacement = "",x[-c(1:4)]))
+  g[g == 0] <- paste0(REF,REF)
+  g[g == 11] <- paste0(ALT,ALT)
+  g[g %in% c(10,1)] <- paste0(REF, ALT)
+  return(g)
+})
+recoded_founder_genos <- t(recoded_founder_genos)
+colnames(recoded_founder_genos) <- colnames(founder_gt)[-c(1:4)]
+founder_gt_renamed <- cbind(founder_gt[,1:4], recoded_founder_genos)
+
 # filter metadata down to samples in the genotype file
-meta <- meta[which(meta$id %in% colnames(sample_gt)),]
+meta <- meta[which(meta$id %in% colnames(sample_gt_renamed)),]
 
 # at this point, metadata sample size should match the quilt sample size
-stopifnot(ncol(sample_gt) == nrow(meta))
-
-message("Getting sample marker positions")
-# Get the marker positions for the samples.
-sample_rr = rowRanges(sample_vcf)
-names(sample_rr) = gsub("[^A-Za-z0-9_]", "_", names(sample_rr))
-rownames(sample_gt) = gsub("[^A-Za-z0-9_]", "_", rownames(sample_gt))
-rm(sample_vcf)
-
-message("Retain SNPs in founder file")
-# Retain the SNPs in the founder file.
-# We may need to revisit this step later, but I'm being conservative.
-common_snps = intersect(rownames(founder_gt), rownames(sample_gt))
-founder_gt  = founder_gt[common_snps,]
-sample_gt   = sample_gt[common_snps,]
-founder_rr  = founder_rr[common_snps,]
-sample_rr   = sample_rr[common_snps,]
-sample_vcf_info = sample_vcf_info[rownames(sample_vcf_info) %in% common_snps,]
-
-# Verify that SNPs line up between founders and samples.
-stopifnot(rownames(founder_gt) == rownames(sample_gt))
-stopifnot(names(founder_rr)    == names(sample_rr))
-stopifnot(rownames(founder_gt) == rownames(sample_vcf_info))
-stopifnot(names(founder_rr) == rownames(sample_vcf_info))
-
-
-# load in data from a failed job with this intermediate file in the Nextflow work directory
-save(founder_gt, founder_rr, sample_gt, sample_rr, sample_vcf_info, 
-     file = paste0("chrom_",chr,"_quilt2qtl2_intermediate.RData"))
-# load("/flashscratch/widmas/QUILT_outputDir/work/2a/02e14676a53c74f27cb603c714fe54/chrom_X_quilt2qtl2_intermediate.RData")
-
+stopifnot(ncol(sample_gt_genos) == nrow(meta))
 
 # how many sites deviate from HWE?
-sample_vcf_info <- data.frame(apply(sample_vcf_info, 2, function(x) unlist(x)))
 if(chr != "X"){
   if(cross_type == "do"){
     print("Pct of sites that deviate from HWE:")
-    paste0(round((table(sample_vcf_info$HWE < 0.05)[[2]]/quilt_variants*100),2),"%")
+    paste0(round((table(sample_gt_renamed$HWE < 0.05)[[2]]/quilt_variants*100),2),"%")
+    
     # filtering by HWE
-    sample_vcf_info <- sample_vcf_info[which(sample_vcf_info$HWE > 0.05),]
+    sample_gt_renamed <- sample_gt_renamed[which(sample_gt_renamed$HWE > 0.05),]
+    
   } else if(cross_type == "bxd"){
     print("BXD strains; sites not expected to adhere to HWE")
     print("Skipping HWE filter")
-    paste0(round((table(sample_vcf_info$HWE < 0.05)[[2]]/quilt_variants*100),2),"%")
+    paste0(round((table(sample_gt_renamed$HWE < 0.05)[[2]]/quilt_variants*100),2),"%")
   } else if(cross_type == "cc"){
     print("CC strains; sites not expected to adhere to HWE")
     print("Skipping HWE filter")
-    paste0(round((table(sample_vcf_info$HWE < 0.05)[[2]]/quilt_variants*100),2),"%")
+    paste0(round((table(sample_gt_renamed$HWE < 0.05)[[2]]/quilt_variants*100),2),"%")
   } else if(cross_type == "het3"){
     print("HET3 strains; sites not expected to adhere to HWE")
     print("Skipping HWE filter")
-    paste0(round((table(sample_vcf_info$HWE < 0.05)[[2]]/quilt_variants*100),2),"%")
+    paste0(round((table(sample_gt_renamed$HWE < 0.05)[[2]]/quilt_variants*100),2),"%")
   } else {
     print("Pct of sites that deviate from HWE:")
-    paste0(round((table(sample_vcf_info$HWE < 0.05)[[2]]/quilt_variants*100),2),"%")
+    paste0(round((table(sample_gt_renamed$HWE < 0.05)[[2]]/quilt_variants*100),2),"%")
+    
     # filtering by HWE
-    sample_vcf_info <- sample_vcf_info[which(sample_vcf_info$HWE > 0.05),]
+    sample_gt_renamed <- sample_gt_renamed[which(sample_gt_renamed$HWE > 0.05),]
   }
 } else {
   print("Chromosome X; sites not necessarily expected to adhere to HWE")
   print("Skipping HWE filter")
-  paste0(round((table(sample_vcf_info$HWE < 0.05)[[2]]/quilt_variants*100),2),"%")
+  paste0(round((table(sample_gt_renamed$HWE < 0.05)[[2]]/quilt_variants*100),2),"%")
 }
 
 # filtering by info score
 lower_info_score <- 0.95
-above_threshold_sites <- length(which(sample_vcf_info$INFO_SCORE > lower_info_score))
-paste0(signif(above_threshold_sites/length(sample_vcf_info$INFO_SCORE), 4)*100,"% of sites above 0.95 INFO score threshold (",above_threshold_sites,")")
+above_threshold_sites <- length(which(sample_gt_renamed$INFO_SCORE > lower_info_score))
+paste0(signif(above_threshold_sites/length(sample_gt_renamed$INFO_SCORE), 4)*100,"% of sites above 0.95 INFO score threshold (",above_threshold_sites,")")
 
 if(above_threshold_sites < 10000){
   message("Fewer than 10,000 sites with info scores > 0.95, setting new threshold and extracting")
@@ -263,78 +249,52 @@ if(above_threshold_sites < 10000){
   new_threshold <- lower_info_score
   while (count < 10000) {
     new_threshold <- new_threshold - 0.01  # Increment the threshold
-    count <- length(which(sample_vcf_info$INFO_SCORE > new_threshold))
+    count <- length(which(sample_gt_renamed$INFO_SCORE > new_threshold))
   }
-  sample_vcf_info = sample_vcf_info[which(sample_vcf_info$INFO_SCORE > new_threshold),]
-  filtered_quilt_variants <- nrow(sample_vcf_info)
+  sample_gt_renamed = sample_gt_renamed[which(sample_gt_renamed$INFO_SCORE > new_threshold),]
+  filtered_quilt_variants <- nrow(sample_gt_renamed)
 } else {
   # This bin is for runs where there were sites above the threshold, but fewer
   message(paste0(above_threshold_sites," info scores above 0.95; keeping just these"))
-  sample_vcf_info = sample_vcf_info[which(sample_vcf_info$INFO_SCORE > lower_info_score),]
-  filtered_quilt_variants <- nrow(sample_vcf_info)
+  sample_gt_renamed = sample_gt_renamed[which(sample_gt_renamed$INFO_SCORE > lower_info_score),]
+  filtered_quilt_variants <- nrow(sample_gt_renamed)
   new_threshold <- lower_info_score
 }
 
-# apply the changes to sample_gt and founder_gt
-founder_gt = founder_gt[rownames(founder_gt) %in% rownames(sample_vcf_info),]
-sample_gt = sample_gt[rownames(sample_gt) %in% rownames(sample_vcf_info),]
-founder_rr = founder_rr[which(names(founder_rr) %in% rownames(sample_vcf_info)),]
-sample_rr = sample_rr[which(names(sample_rr) %in% rownames(sample_vcf_info)),]
-filtered_quilt_variants <- nrow(sample_gt)
+# apply the changes to founder_gt
+founder_gt_renamed = founder_gt_renamed[rownames(founder_gt_renamed) %in% rownames(sample_gt_renamed),]
+filtered_quilt_variants <- nrow(sample_gt_renamed)
 resolution_summary <- data.frame(quilt_variants,filtered_quilt_variants, new_threshold)
 resolution_summary$chr <- chr
 write.csv(resolution_summary, paste0("chr",chr,"_resolution_summary.csv"), quote = F, row.names = F)
 
-# Make heterozygous alleles consistent.
-gt_num = t(sample_gt)
-gt_num[gt_num == 'CA'] = 'AC'
-gt_num[gt_num == 'GA'] = 'AG'
-gt_num[gt_num == 'TA'] = 'AT' 
-gt_num[gt_num == 'GC'] = 'CG'
-gt_num[gt_num == 'TC'] = 'CT'
-gt_num[gt_num == 'TG'] = 'GT'
-
-
-message("Convert genotypes to numerics")
-# Convert genotypes to numbers.
-# Note that the SNP names will be messed up by the data.frame.
-gt_num = data.frame(gt_num, stringsAsFactors = TRUE)
-# How many alleles do we have?
-message("How many alleles do we have?")
-num_geno = sapply(lapply(gt_num, levels), length)
-table(num_geno)
-
-# Verify that SNPs line up between founders and samples.
-stopifnot(rownames(founder_gt) == rownames(sample_gt))
-stopifnot(names(founder_rr)    == names(sample_rr))
-
 # Merge founders and samples together.
-all_gt = base::merge(founder_gt, sample_gt, by = 'row.names',
-                     all.x = TRUE, sort = FALSE)
-rownames(all_gt) = all_gt$Row.names
-all_gt = as.matrix(all_gt[,-1])
-
+all_gt <- dplyr::full_join(founder_gt_renamed, sample_gt_renamed) %>%
+  dplyr::select(-HWE, -INFO_SCORE) %>%
+  dplyr::arrange(CHROM, POS)
+rownames(all_gt) <- rownames(founder_gt_renamed)
 
 message("Get allele codes for each SNP")
 # Get the allele codes for each SNP.
-ref = as.character(founder_rr$REF)
-alt = as.character(unlist(founder_rr$ALT))
+ref = as.character(all_gt$REF)
+alt = as.character(all_gt$ALT)
 alleles = cbind(ref, alt)
 rm(ref, alt)
 
-# Encode the genotypes from qtl2.
+#Encode the genotypes from qtl2.
+all_gt_meta <- all_gt[,1:4]
 if(cross_type == "bxd"){
-  all_gt = encode_geno(all_gt, alleles, output_codes = c("-","B","H","D"))
+  all_gt = encode_geno(all_gt[,-c(1:4)], alleles, output_codes = c("-","B","H","D"))
 } else {
-  all_gt = encode_geno(all_gt, alleles)
+  all_gt = encode_geno(all_gt[,-c(1:4)], alleles)
 }
+all_gt <- cbind(all_gt_meta, all_gt)
 
-# Subset the samples to include informative SNPs.
-sample_gt = all_gt[,colnames(sample_gt)]
 
-# Write out the founders.
-# NOTE: Don't forget to change the order to the standard order!
-founder_gt = all_gt[,!colnames(all_gt) %in% colnames(sample_gt)]
+# format founder genos for qtl2
+founder_gt <- all_gt %>%
+  dplyr::select(colnames(founder_gt_renamed)[-c(1:4)])
+
 if(cross_type == "do"){
   
   colnames(founder_gt) = LETTERS[1:ncol(founder_gt)]
@@ -360,26 +320,26 @@ write.csv(founder_gt, file = paste0("chr",chr,"_founder_geno.csv"),
           quote = FALSE, row.names = FALSE)
 
 # Write out sample genotypes.
-# keep an eye on the column names here - if there are parsing errors downstream,
-# this might be why
+sample_gt <- all_gt %>%
+  dplyr::select(colnames(sample_gt_renamed)[-c(1:6)])
 sample_gt = data.frame(marker = rownames(sample_gt), 
                        sample_gt, check.names = F)
 write.csv(sample_gt, file = paste0("chr",chr,"_sample_geno.csv"),
           quote = FALSE, row.names = FALSE)
 
 # Write out physical map.
-pmap = data.frame(marker = names(founder_rr),
-                  chr    = seqnames(founder_rr),
-                  pos    = start(founder_rr) * 1e-6)
+pmap = data.frame(marker = rownames(founder_gt_renamed),
+                  chr    = founder_gt_renamed$CHROM,
+                  pos    = founder_gt_renamed$POS * 1e-6)
 write.csv(pmap, file = paste0("chr",chr,"_pmap.csv"),
           quote = FALSE, row.names = FALSE)
 
 # Write out genetic map.
 markers = read.delim(marker_file, sep = ' ')
-markers = subset(markers, position %in% start(founder_rr))
-stopifnot(markers$position == start(founder_rr))
-gmap = data.frame(marker = names(founder_rr),
-                  chr    = seqnames(founder_rr),
+markers = subset(markers, position %in% founder_gt_renamed$POS)
+stopifnot(markers$position == founder_gt_renamed$POS)
+gmap = data.frame(marker = rownames(founder_gt_renamed),
+                  chr    = founder_gt_renamed$CHROM,
                   pos    = markers$Genetic_Map.cM.)
 write.csv(gmap, file = paste0("chr",chr,"_gmap.csv"),
           quote = FALSE, row.names = FALSE)

--- a/bin/quilt/prepare_qtl2_files.R
+++ b/bin/quilt/prepare_qtl2_files.R
@@ -1,3 +1,5 @@
+#!/usr/bin/env Rscript
+
 ################################################################################
 # Gather genotypes, markers, & covariates and format for qtl2::read_cross().
 # GRCm39.
@@ -7,8 +9,6 @@
 # 2025-02-11
 ################################################################################
 
-# library(readxl)
-# library(VariantAnnotation)
 library(qtl2convert)
 library(qtl2)
 library(stringr)
@@ -46,23 +46,28 @@ marker_file = args[5]
 chr = args[6]
 
 ##### TROUBLESHOOTING FILES #####
-# # Founder genotypes and marker positions
-# founder_file = '/projects/compsci/vmp/USERS/widmas/quilt-nf/chr19_fg.txt'
-# 
+# # # Founder genotypes and marker positions
+# test_dir <- "/flashscratch/widmas/QUILT/work/62/d2811bd7346cd0c440e9b2b1e8b5cf"
+# setwd(test_dir)
+# founder_file = list.files(pattern = "fg.txt", full.names = T)
+# #
 # # Sample genotypes from QUILT.
-# sample_file = "/projects/compsci/vmp/USERS/widmas/quilt-nf/chr19_sg.txt"
-# 
+# sample_file = list.files(pattern = "sg.txt", full.names = T)
+# #
 # # Sample metadata file.
 # meta_file = '/projects/compsci/vmp/USERS/widmas/quilt-nf/data/DO_covar.csv'
-# 
+# #
 # # Cross type
 # cross_type = 'do'
-# 
-# # Marker map.
-# marker_file = '/projects/compsci/vmp/USERS/widmas/quilt-nf/reference_data/do/chr19_gen_map.txt'
+# #
 # 
 # # chromosome
-# chr = "19"
+# chr = "2"
+# 
+# # Marker map.
+# marker_file = file.path('/projects/compsci/vmp/USERS/widmas/quilt-nf/reference_data/do',
+#                         paste0("chr",chr,"_gen_map.txt"))
+
 
 
 
@@ -207,8 +212,6 @@ stopifnot(ncol(sample_gt_genos) == nrow(meta))
 # how many sites deviate from HWE?
 if(chr != "X"){
   if(cross_type == "do"){
-    print("Pct of sites that deviate from HWE:")
-    paste0(round((table(sample_gt_renamed$HWE < 0.05)[[2]]/quilt_variants*100),2),"%")
     
     # filtering by HWE
     sample_gt_renamed <- sample_gt_renamed[which(sample_gt_renamed$HWE > 0.05),]
@@ -216,18 +219,18 @@ if(chr != "X"){
   } else if(cross_type == "bxd"){
     print("BXD strains; sites not expected to adhere to HWE")
     print("Skipping HWE filter")
-    paste0(round((table(sample_gt_renamed$HWE < 0.05)[[2]]/quilt_variants*100),2),"%")
+    # paste0(round((table(sample_gt_renamed$HWE < 0.05)[[2]]/quilt_variants*100),2),"%")
   } else if(cross_type == "cc"){
     print("CC strains; sites not expected to adhere to HWE")
     print("Skipping HWE filter")
-    paste0(round((table(sample_gt_renamed$HWE < 0.05)[[2]]/quilt_variants*100),2),"%")
+    # paste0(round((table(sample_gt_renamed$HWE < 0.05)[[2]]/quilt_variants*100),2),"%")
   } else if(cross_type == "het3"){
     print("HET3 strains; sites not expected to adhere to HWE")
     print("Skipping HWE filter")
-    paste0(round((table(sample_gt_renamed$HWE < 0.05)[[2]]/quilt_variants*100),2),"%")
+    # paste0(round((table(sample_gt_renamed$HWE < 0.05)[[2]]/quilt_variants*100),2),"%")
   } else {
     print("Pct of sites that deviate from HWE:")
-    paste0(round((table(sample_gt_renamed$HWE < 0.05)[[2]]/quilt_variants*100),2),"%")
+    # paste0(round((table(sample_gt_renamed$HWE < 0.05)[[2]]/quilt_variants*100),2),"%")
     
     # filtering by HWE
     sample_gt_renamed <- sample_gt_renamed[which(sample_gt_renamed$HWE > 0.05),]
@@ -235,7 +238,7 @@ if(chr != "X"){
 } else {
   print("Chromosome X; sites not necessarily expected to adhere to HWE")
   print("Skipping HWE filter")
-  paste0(round((table(sample_gt_renamed$HWE < 0.05)[[2]]/quilt_variants*100),2),"%")
+  # paste0(round((table(sample_gt_renamed$HWE < 0.05)[[2]]/quilt_variants*100),2),"%")
 }
 
 # filtering by info score
@@ -243,23 +246,23 @@ lower_info_score <- 0.95
 above_threshold_sites <- length(which(sample_gt_renamed$INFO_SCORE > lower_info_score))
 paste0(signif(above_threshold_sites/length(sample_gt_renamed$INFO_SCORE), 4)*100,"% of sites above 0.95 INFO score threshold (",above_threshold_sites,")")
 
-if(above_threshold_sites < 10000){
-  message("Fewer than 10,000 sites with info scores > 0.95, setting new threshold and extracting")
-  count <- 0
-  new_threshold <- lower_info_score
-  while (count < 10000) {
-    new_threshold <- new_threshold - 0.01  # Increment the threshold
-    count <- length(which(sample_gt_renamed$INFO_SCORE > new_threshold))
-  }
-  sample_gt_renamed = sample_gt_renamed[which(sample_gt_renamed$INFO_SCORE > new_threshold),]
-  filtered_quilt_variants <- nrow(sample_gt_renamed)
-} else {
-  # This bin is for runs where there were sites above the threshold, but fewer
-  message(paste0(above_threshold_sites," info scores above 0.95; keeping just these"))
-  sample_gt_renamed = sample_gt_renamed[which(sample_gt_renamed$INFO_SCORE > lower_info_score),]
-  filtered_quilt_variants <- nrow(sample_gt_renamed)
-  new_threshold <- lower_info_score
-}
+# if(above_threshold_sites < 10000){
+#   message("Fewer than 10,000 sites with info scores > 0.95, setting new threshold and extracting")
+#   count <- 0
+#   new_threshold <- lower_info_score
+#   while (count < 10000) {
+#     new_threshold <- new_threshold - 0.01  # Increment the threshold
+#     count <- length(which(sample_gt_renamed$INFO_SCORE > new_threshold))
+#   }
+#   sample_gt_renamed = sample_gt_renamed[which(sample_gt_renamed$INFO_SCORE > new_threshold),]
+#   filtered_quilt_variants <- nrow(sample_gt_renamed)
+# } else {
+# This bin is for runs where there were sites above the threshold, but fewer
+message(paste0(above_threshold_sites," info scores above 0.95"))
+sample_gt_renamed = sample_gt_renamed[which(sample_gt_renamed$INFO_SCORE > lower_info_score),]
+filtered_quilt_variants <- nrow(sample_gt_renamed)
+new_threshold <- lower_info_score
+
 
 # apply the changes to founder_gt
 founder_gt_renamed = founder_gt_renamed[rownames(founder_gt_renamed) %in% rownames(sample_gt_renamed),]

--- a/bin/quilt/run_quilt.R
+++ b/bin/quilt/run_quilt.R
@@ -19,9 +19,9 @@ args <- commandArgs(trailingOnly = TRUE)
 #args[2] = chromosome number (from channel)
 #args[3] = covar file
 #args[4] = cross type
-#args[5] = reference haplotype file (if DO)
-#args[6] = reference sample file (if DO)
-#args[7] = reference legend file (if DO)
+#args[5] = reference haplotype file
+#args[6] = reference sample file
+#args[7] = reference legend file
 #args[8] = bin shuffle radius
 
 # Input files
@@ -42,10 +42,20 @@ covar <- read.csv(meta_file)
 cross_type <- args[4]
 
 # Reference files
-hap <- args[5]
-samp <- args[6]
-leg <- args[7]
-rad <- args[8]
+hap   <- args[5]
+samp  <- args[6]
+leg   <- args[7]
+rad   <- args[8]
+
+# Region data
+options(scipen = 99999999)
+start <- as.integer(args[9])
+end   <- as.integer(args[10])
+print(args)
+str(args[9])
+str(args[10])
+str(start)
+str(end)
 
 # Take cross type and determine how QUILT should be executed
 if(cross_type == "do" | cross_type == "cc" | cross_type == "het3"){
@@ -62,9 +72,9 @@ if(cross_type == "do" | cross_type == "cc" | cross_type == "het3"){
   covar_nGen <- median(covar$gen[!is.na(covar$gen)])
   
   QUILT::QUILT(chr = mouse_chr,
-               #regionStart = 5000000, # remove when not testing
-               #regionEnd = 10000000, # remove when not testing
-               #buffer = 10000, # remove when not testing
+               regionStart = start,
+               regionEnd = end,
+               buffer = 10000,
                bamlist = mouse_bamlist,
                outputdir = paste0(getwd(), "/"),
                reference_haplotype_file = hap,
@@ -83,9 +93,9 @@ if(cross_type == "do" | cross_type == "cc" | cross_type == "het3"){
   covar_nGen <- 20
   
   QUILT::QUILT(chr = mouse_chr,
-               #regionStart = 5000000, # remove when not testing
-               #regionEnd = 10000000, # remove when not testing
-               #buffer = 10000, # remove when not testing
+               regionStart = start, # remove when not testing
+               regionEnd = end, # remove when not testing
+               buffer = 10000, # remove when not testing
                bamlist = mouse_bamlist,
                outputdir = paste0(getwd(), "/"),
                reference_haplotype_file = hap,

--- a/bin/quilt/smooth_genoprobs.R
+++ b/bin/quilt/smooth_genoprobs.R
@@ -1,0 +1,101 @@
+#!/usr/bin/env Rscript
+
+################################################################################
+# Count crossovers from QUILT-based haplotype reconstructions using Dan Gatti's
+# new correlation-based method.
+#
+# Sam Widmayer
+# samuel.widmayer@jax.org
+# 20250210
+################################################################################
+
+library(qtl2)
+library(tidyr)
+library(dplyr)
+args <- commandArgs(trailingOnly = TRUE)
+# test_dir <- "/flashscratch/widmas/QUILT/work/bf/6aaabd153b11c4d95559305af20348"
+# setwd(test_dir)
+
+# genotype prob objects
+genoprobs <-  args[1]
+# genoprobs <- "chr_2_36_state_probs.RData"
+load(genoprobs)
+
+# cross objects
+cross <- args[2]
+# cross <- "chr_2_cross.RData"
+load(cross)
+
+# downsample level
+downsample_level <- args[3]
+# downsample_level <- "0.005"
+
+# bin shuffle param was added at some point but want to keep this flexible
+bin_shuffle <- args[4]
+# bin_shuffle <- "2000"
+
+# correlation threshold for primary prob call
+prob_cor_thresh <- args[5]
+# prob_cor_thresh <- "0.5"
+
+# chromosome
+chrom <- args[6]
+# chrom <- "2"
+
+# source counting function
+hap_block_functions <- args[7]
+# hap_block_functions <- "/projects/compsci/vmp/USERS/widmas/quilt-nf/bin/quilt/get_hap_blocks.R"
+source(hap_block_functions)
+
+# get haplotype blocks one sample at a time
+samples = qtl2::ind_ids(cross)
+getHapBlocks <- function(ind){
+
+  message(ind)
+  
+  # probs
+  p = pr[[1]][ind,,]
+  m = cross$pmap[[1]]
+  
+  # get haplotype blocks
+  haps <- get_blocks_1sample(probs = p, mkrs = m, 
+                             cor_thr = prob_cor_thresh)
+  haps2 <- haps %>%
+    dplyr::mutate(sample = ind)
+  return(haps2)
+}
+hap_block_list <- lapply(samples, getHapBlocks)
+hap_blocks_df <- Reduce(rbind,hap_block_list) %>%
+  dplyr::mutate(block_size = (as.numeric(dist_pos)-as.numeric(prox_pos)),
+                marker_distance = dist_idx-prox_idx)
+
+# identify potentially spurious blocks
+flagged_blocks <- hap_blocks_df %>%
+  dplyr::filter(marker_distance < 5) %>%
+  dplyr::filter(block_size < 0.01)
+
+# grab marker names
+idx_list <- vector("list", nrow(flagged_blocks))
+for(i in 1:nrow(flagged_blocks)){
+  idx_df <- data.frame(seq(flagged_blocks[i,]$prox_idx,flagged_blocks[i,]$dist_idx),
+             flagged_blocks[i,]$sample)
+  colnames(idx_df) <- c("idx","sample")
+  idx_list[[i]] <- idx_df
+}
+idx_samples_df <- Reduce(rbind,idx_list)
+flagged_markers <- sort(unique(idx_samples_df$idx))
+flagged_markers <- names(cross$pmap[[1]][flagged_markers])
+
+# remove the spurious markers
+cross <- qtl2::drop_markers(cross, markers = flagged_markers)
+
+# Calculate genotype probs
+pr <- qtl2::calc_genoprob(cross = cross, 
+                          map = cross$pmap, 
+                          error_prob = 0.002, 
+                          cores = (parallel::detectCores()/2), quiet = F)
+
+# Save objects
+save(cross, file = paste0("chr_",chrom,"_cross_smooth.RData"))
+save(pr, file = paste0("chr_",chrom,"_36_state_probs_smooth.RData"))
+

--- a/bin/shared/create_a_grid.R
+++ b/bin/shared/create_a_grid.R
@@ -9,7 +9,7 @@ quilt_dir <- "/projects/compsci/vmp/USERS/widmas/quilt-nf"
 cross_type <- "do"
 
 # grid size
-grid_size_M <- 1
+grid_size_M <- 0.25
 
 # chromsome coordinates
 ref_maps <- list.files(file.path(quilt_dir,"reference_data",cross_type), pattern = "gen_map", full.names = T)
@@ -29,10 +29,10 @@ map_bed <- dplyr::arrange(map_bed, chr) %>%
 map_bed$total <- sum(map_bed$width)
 map_bed$prop <- map_bed$width/map_bed$total
 map_bed$n_markers <- round((grid_size_M*1e6)*map_bed$prop,0)
-if(sum(map_bed$n_markers) < 1e6){
-  rem <- 1e6-sum(map_bed$n_markers)
-  map_bed$n_markers[20] <- map_bed$n_markers[20]+rem
-}
+# if(sum(map_bed$n_markers) < 1e6){
+#   rem <- 1e6-sum(map_bed$n_markers)
+#   map_bed$n_markers[20] <- map_bed$n_markers[20]+rem
+# }
 
 # get marker grid
 grids <- list()

--- a/config/profiles/sumner2.config
+++ b/config/profiles/sumner2.config
@@ -16,7 +16,7 @@ process {
 executor {
     name = 'slurm'
     // The number of tasks the executor will handle in a parallel manner
-    queueSize = 150
-    submitRateLimit = '1 / 2 s'
+    queueSize = 200
+    submitRateLimit = '1/2s'
     // Determines the max rate of job submission per time unit, for example '10sec' eg. max 10 jobs per second or '1/2 s' i.e. 1 job submissions every 2 seconds.
 }

--- a/modules/bcftools/make_haplegendsample.nf
+++ b/modules/bcftools/make_haplegendsample.nf
@@ -5,21 +5,27 @@ process MAKE_REF_HAPLOTYPES {
 
   container 'quay.io/biocontainers/bcftools:1.21--h8b25389_0'
 
-  publishDir "${projectDir}/reference_data/${params.cross_type}", pattern:"*.hap.gz", mode:'copy', overwrite: false
-  publishDir "${projectDir}/reference_data/${params.cross_type}", pattern:"*.legend.gz", mode:'copy', overwrite: false
-  publishDir "${projectDir}/reference_data/${params.cross_type}", pattern:"*.samples", mode:'copy', overwrite: false
+  publishDir "${projectDir}/reference_data/${params.cross_type}", pattern:"*.hap.gz", mode:'copy', overwrite: true
+  publishDir "${projectDir}/reference_data/${params.cross_type}", pattern:"*.legend.gz", mode:'copy', overwrite: true
+  publishDir "${projectDir}/reference_data/${params.cross_type}", pattern:"*.samples", mode:'copy', overwrite: true
+  publishDir "${projectDir}/reference_data/${params.cross_type}", pattern:"*_phased_snps.vcf.gz.tbi", mode:'copy', overwrite: true
   
   input:
   tuple val(chr), file(phased_vcf)
 
   output:
   tuple val(chr), file("*.hap.gz"), file("*.legend.gz"), file("*.samples"), emit: haplegendsample
+  tuple val(chr), file("*_phased_snps.vcf.gz.tbi"), emit: phased_vcf_tbi
   
   script:
 
   """
+  # index vcf
+  tabix -p vcf ${phased_vcf}
+
   # make haplegendsample files
   bcftools convert ${phased_vcf} --haplegendsample chr${chr}
+  
   """
 
   stub:

--- a/modules/bcftools/phase_founder_vcf.nf
+++ b/modules/bcftools/phase_founder_vcf.nf
@@ -5,7 +5,7 @@ process PHASE_FOUNDER_VCF {
 
   container 'quay.io/biocontainers/bcftools:1.21--h8b25389_0'
   
-  publishDir "${projectDir}/reference_data/${params.cross_type}", pattern:"*_phased_snps.vcf.gz", mode:'copy', overwrite: false
+  publishDir "${projectDir}/reference_data/${params.cross_type}", pattern:"*_phased_snps.vcf.gz", mode:'copy', overwrite: true
   
   input:
   tuple val(chr), file(merged_vcf)
@@ -16,12 +16,13 @@ process PHASE_FOUNDER_VCF {
   script:
   
   """
-  zcat ${merged_vcf} | sed '/^##/! s/\\//\\|/g' > chr${chr}_phased_snps.vcf.gz
+  zcat ${merged_vcf} | sed '/^##/! s/\\//\\|/g' > chr${chr}_phased_snps.vcf
+  bgzip chr${chr}_phased_snps.vcf
   """
 
   stub:
 
   """
-  touch test_phased_snps.vcf.gz
+  touch test_phased_snps.vcf
   """
 }

--- a/modules/quilt/concatenate_genoprobs.nf
+++ b/modules/quilt/concatenate_genoprobs.nf
@@ -1,6 +1,6 @@
 process CONCATENATE_GENOPROBS {
 
-  cpus 1
+  cpus 2
   memory {200.GB * task.attempt}
   time {1.hour * task.attempt}
   errorStrategy 'retry' 
@@ -11,10 +11,10 @@ process CONCATENATE_GENOPROBS {
   publishDir "${params.pubdir}/${params.run_name}/${downsample_to_cov}/${shuffle_bin_radius}/geno_probs", pattern:"*.rds", mode:'copy', overwrite: true
   
   input:
-  tuple val(chrs), val(downsample_to_cov), val(shuffle_bin_radius), file(genoprobs), file(crosses)
+  tuple val(downsample_to_cov), val(shuffle_bin_radius), file(genoprobs), file(pmaps)
 
   output:
-  tuple val(chrs), val(downsample_to_cov), val(shuffle_bin_radius), file("complete_cross.rds"), file("complete_genoprobs.rds"), file("complete_alleleprobs.rds"), emit: concat_probs
+  tuple val(downsample_to_cov), val(shuffle_bin_radius), file("complete_pmap.rds"), file("complete_genoprobs.rds"), file("complete_alleleprobs.rds"), emit: concat_probs
 
   script:
 

--- a/modules/quilt/genoprobs.nf
+++ b/modules/quilt/genoprobs.nf
@@ -3,10 +3,9 @@ process GENOPROBS {
 
   cpus 1
   memory {400.GB * task.attempt}
-  time {11.hour * task.attempt}
+  time {12.hour * task.attempt}
   errorStrategy 'retry' 
   maxRetries 1
-
 
   container 'docker://sjwidmay/lcgbs_hr:latest'
   

--- a/modules/quilt/genoprobs.nf
+++ b/modules/quilt/genoprobs.nf
@@ -1,8 +1,8 @@
 process GENOPROBS {
   tag "$chr, $downsample_to_cov"
 
-  cpus 1
-  memory {400.GB * task.attempt}
+  cpus 2
+  memory {200.GB * task.attempt}
   time {12.hour * task.attempt}
   errorStrategy 'retry' 
   maxRetries 1
@@ -10,10 +10,10 @@ process GENOPROBS {
   container 'docker://sjwidmay/lcgbs_hr:latest'
   
   input:
-  tuple val(chr), val(downsample_to_cov), val(shuffle_bin_radius), file(founder_geno), file(sample_genos), file(pmap), file(gmap), file(covar), file(pheno)
+  tuple val(chr), val(downsample_to_cov), val(start), val(stop), val(shuffle_bin_radius), file(founder_geno), file(sample_genos), file(pmap), file(gmap), file(covar), file(pheno)
 
   output:
-  tuple val(chr), val(downsample_to_cov), val(shuffle_bin_radius), file("*36_state_probs.RData"), file("*_cross.RData"), emit: geno_probs_out
+  tuple val(chr), val(downsample_to_cov), val(start), val(stop), val(shuffle_bin_radius), file("*36_state_probs.RData"), file("*_cross.RData"), emit: geno_probs_out, optional: true
 
   script:
 

--- a/modules/quilt/interpolate_genoprobs.nf
+++ b/modules/quilt/interpolate_genoprobs.nf
@@ -1,0 +1,30 @@
+process INTERPOLATE_GENOPROBS {
+
+  cpus 1
+  memory 10.GB
+  time 1.hour
+
+  container 'docker://sjwidmay/lcgbs_hr:latest'
+  
+  input: 
+  tuple val(chr), val(downsample_to_cov), val(start), val(stop), val(shuffle_bin_radius), file(genoprobs), file(cross)
+
+  output:
+  tuple val(chr), val(downsample_to_cov), val(shuffle_bin_radius), file("*_pr.rds"), file("*_map.rds"), file("*_cross.rds"), emit: interpolated_probs
+
+  script:
+
+  """
+  echo "${chr}-${start}:${stop}"
+
+  Rscript --vanilla ${projectDir}/bin/quilt/interpolate_quilt_genoprobs.R ${chr} \
+	${start} \
+	${stop} \
+	${genoprobs} \
+	${cross} \
+    ${params.gridfile} \
+    ${projectDir}/bin/quilt/interpolate_genoprobs.R
+  """
+
+
+}

--- a/modules/quilt/merge_chrom_probs.nf
+++ b/modules/quilt/merge_chrom_probs.nf
@@ -1,0 +1,21 @@
+process MERGE_CHROMS {
+
+  cpus 1
+  memory 10.GB
+  time 1.hour
+
+  container 'docker://sjwidmay/lcgbs_hr:latest'
+  
+  input: 
+  tuple val(chr), val(downsample_to_cov), val(shuffle_bin_radius), file(genoprobs), file(maps), file(original_crosses)
+
+  output:
+  tuple val(downsample_to_cov), val(shuffle_bin_radius), file("*_genoprobs.rds"), file("*_pmap.rds"), emit: chr_merged_probs
+
+  script:
+
+  """
+  Rscript --vanilla ${projectDir}/bin/quilt/merge_chrom_probs.R ${chr}
+  """
+
+}

--- a/modules/quilt/quilt_to_qtl2.nf
+++ b/modules/quilt/quilt_to_qtl2.nf
@@ -1,13 +1,13 @@
 process QUILT_TO_QTL2 {
   tag "$chr, $downsample_to_cov"
 
-  time {60.min * task.attempt}
+  time 60.min
   cpus 1
-  memory {60.GB * task.attempt}
+  memory 10.GB
   maxRetries 1
   errorStrategy 'retry'
 
-  container 'docker://sjwidmay/variantannotation:latest'
+  container 'docker://sjwidmay/bcftools_qtl2:latest'
 
   publishDir "${params.pubdir}/${params.run_name}/${downsample_to_cov}/${shuffle_bin_radius}/geno_probs", pattern:"covar.csv", mode:'copy', overwrite: true
   publishDir "${params.pubdir}/${params.run_name}/${downsample_to_cov}/${shuffle_bin_radius}/geno_probs", pattern:"pheno.csv", mode:'copy', overwrite: true
@@ -22,10 +22,22 @@ process QUILT_TO_QTL2 {
   script:
 
   """
-  Rscript --vanilla ${projectDir}/bin/quilt/prepare_qtl2_files.R ${projectDir}/reference_data/${params.cross_type}/chr${chr}_phased_snps.vcf.gz \
-	${sample_genos} \
-	${params.covar_file} \
-	${params.cross_type} \
-	${projectDir}/reference_data/${params.cross_type}/chr${chr}_gen_map.txt ${chr}
+  # make founder geno table
+  bcftools query --print-header -f '%CHROM\\t%POS\\t%REF\\t%ALT[\\t%GT]\\n' ${projectDir}/reference_data/${params.cross_type}/chr${chr}_phased_snps.vcf.gz | \
+        sed 's/[[# 0-9]*]//g' | \
+        sed 's/:GT//g' > chr${chr}_fg.txt
+
+  # make sample geno table
+  bcftools query --print-header -f '%CHROM\\t%POS\\t%REF\\t%ALT\\t%INFO/HWE\\t%INFO/INFO_SCORE[\\t%GT]\\n' ${sample_genos} | \
+        sed 's/[[# 0-9]*]//g' | \
+        sed 's/:GT//g' > chr${chr}_sg.txt
+  
+
+  Rscript --vanilla ${projectDir}/bin/quilt/prepare_qtl2_files.R chr${chr}_fg.txt \
+	  chr${chr}_sg.txt \
+	  ${params.covar_file} \
+	  ${params.cross_type} \
+	  ${projectDir}/reference_data/${params.cross_type}/chr${chr}_gen_map.txt \
+    ${chr}
   """
 }

--- a/modules/quilt/quilt_to_qtl2.nf
+++ b/modules/quilt/quilt_to_qtl2.nf
@@ -3,32 +3,31 @@ process QUILT_TO_QTL2 {
 
   time 60.min
   cpus 1
-  memory 10.GB
+  memory {50.GB * task.attempt}
   maxRetries 1
   errorStrategy 'retry'
 
   container 'docker://sjwidmay/bcftools_qtl2:latest'
 
-  publishDir "${params.pubdir}/${params.run_name}/${downsample_to_cov}/${shuffle_bin_radius}/geno_probs", pattern:"covar.csv", mode:'copy', overwrite: true
-  publishDir "${params.pubdir}/${params.run_name}/${downsample_to_cov}/${shuffle_bin_radius}/geno_probs", pattern:"pheno.csv", mode:'copy', overwrite: true
+  //publishDir "${params.pubdir}/${params.run_name}/${downsample_to_cov}/${shuffle_bin_radius}/geno_probs", pattern:"*_resolution_summary.csv", mode:'copy', overwrite: true
 
   input:
-  tuple val(chr), val(downsample_to_cov), val(shuffle_bin_radius), file(sample_genos), file(sample_genos_index)
+  tuple val(chr), val(downsample_to_cov), val(start), val(stop), val(shuffle_bin_radius), file(sample_genos), file(sample_genos_index)
 
   output:
-  tuple val(chr), val(downsample_to_cov), val(shuffle_bin_radius), file("*_founder_geno.csv"), file("*_sample_geno.csv"), file("*_pmap.csv"), file("*_gmap.csv"), file("covar.csv"), file("pheno.csv"), emit: qtl2files
+  tuple val(chr), val(downsample_to_cov), val(start), val(stop), val(shuffle_bin_radius), file("*_founder_geno.csv"), file("*_sample_geno.csv"), file("*_pmap.csv"), file("*_gmap.csv"), file("covar.csv"), file("pheno.csv"), emit: qtl2files
   tuple val(chr), file("*_resolution_summary.csv"), emit: resolution_summary
 
   script:
 
   """
   # make founder geno table
-  bcftools query --print-header -f '%CHROM\\t%POS\\t%REF\\t%ALT[\\t%GT]\\n' ${projectDir}/reference_data/${params.cross_type}/chr${chr}_phased_snps.vcf.gz | \
+  bcftools query --print-header -f '%CHROM\\t%POS\\t%REF\\t%ALT[\\t%GT]\\n' -r ${chr}:${start}-${stop} ${projectDir}/reference_data/${params.cross_type}/chr${chr}_phased_snps.vcf.gz | \
         sed 's/[[# 0-9]*]//g' | \
         sed 's/:GT//g' > chr${chr}_fg.txt
 
   # make sample geno table
-  bcftools query --print-header -f '%CHROM\\t%POS\\t%REF\\t%ALT\\t%INFO/HWE\\t%INFO/INFO_SCORE[\\t%GT]\\n' ${sample_genos} | \
+  bcftools query --print-header -f '%CHROM\\t%POS\\t%REF\\t%ALT\\t%INFO/HWE\\t%INFO/INFO_SCORE[\\t%GT]\\n' -r ${chr}:${start}-${stop} ${sample_genos} | \
         sed 's/[[# 0-9]*]//g' | \
         sed 's/:GT//g' > chr${chr}_sg.txt
   
@@ -38,6 +37,6 @@ process QUILT_TO_QTL2 {
 	  ${params.covar_file} \
 	  ${params.cross_type} \
 	  ${projectDir}/reference_data/${params.cross_type}/chr${chr}_gen_map.txt \
-    ${chr}
+        ${chr}
   """
 }

--- a/modules/quilt/run_quilt.nf
+++ b/modules/quilt/run_quilt.nf
@@ -1,8 +1,7 @@
 process RUN_QUILT {
-  tag "$chr, $downsample_to_cov"
   
-  memory 300.GB
-  time {4.hour * task.attempt}
+  memory {100.GB * 1.5 * task.attempt}
+  time 4.hour
   cpus 1
   errorStrategy 'retry' 
   maxRetries 1
@@ -10,13 +9,13 @@ process RUN_QUILT {
   
   container 'docker://sjwidmay/quilt-nf:latest'
 
-  publishDir "${params.pubdir}/${params.run_name}/${downsample_to_cov}/${shuffle_bin_radius}/quilt_vcfs", pattern:"*", mode:'copy'
+  // publishDir "${params.pubdir}/${params.run_name}/${downsample_to_cov}/${shuffle_bin_radius}/quilt_vcfs", pattern:"*", mode:'copy'
   
   input:
-  tuple file(bamlist), val(downsample_to_cov), val(chr), val(shuffle_bin_radius)
+  tuple file(bamlist), val(downsample_to_cov), val(chr), val(start), val(stop), val(shuffle_bin_radius)
 
   output:
-  tuple val(chr), val(downsample_to_cov), val(shuffle_bin_radius), file("quilt.*.vcf.gz"), file("quilt.*.vcf.gz.tbi"), emit: quilt_vcf
+  tuple val(chr), val(downsample_to_cov), val(start), val(stop), val(shuffle_bin_radius), file("quilt.*.vcf.gz"), file("quilt.*.vcf.gz.tbi"), emit: quilt_vcf
 
   script:
 
@@ -28,6 +27,8 @@ process RUN_QUILT {
       ${projectDir}/reference_data/${params.cross_type}/chr${chr}.hap.gz \
       ${projectDir}/reference_data/${params.cross_type}/chr${chr}.samples \
       ${projectDir}/reference_data/${params.cross_type}/chr${chr}.legend.gz \
-      ${shuffle_bin_radius}
+      ${shuffle_bin_radius} \
+      ${start} \
+      ${stop}
   """
 }

--- a/modules/quilt/smooth_genoprobs.nf
+++ b/modules/quilt/smooth_genoprobs.nf
@@ -1,20 +1,20 @@
 process SMOOTH_GENOPROBS {
 
+  tag "$chr, $downsample_to_cov"
+
   cpus 1
-  memory {200.GB * task.attempt}
-  time {1.hour * task.attempt}
+  memory {320.GB * task.attempt}
+  time {11.hour * task.attempt}
   errorStrategy 'retry' 
   maxRetries 1
 
   container 'docker://sjwidmay/lcgbs_hr:latest'
-
-  publishDir "${params.pubdir}/${params.run_name}/${downsample_to_cov}/${shuffle_bin_radius}/geno_probs", pattern:"*_smooth.rds", mode:'copy', overwrite: true
   
   input:
-  tuple val(chrs), val(downsample_to_cov), val(shuffle_bin_radius), file(cross), file(geno_probs), file(allele_probs)
+  tuple val(chr), val(downsample_to_cov), val(shuffle_bin_radius), file(geno_probs), file(cross)
 
   output:
-  tuple val(chrs), val(downsample_to_cov), val(shuffle_bin_radius), file("complete_cross_smooth.rds"), file("complete_genoprobs_smooth.rds"), file("complete_alleleprobs_smooth.rds"), emit: smooth_probs
+  tuple val(chr), val(downsample_to_cov), val(shuffle_bin_radius), file("*_36_state_probs_smooth.RData"), file("*_cross_smooth.RData"), emit: smooth_probs
 
   script:
 
@@ -24,6 +24,7 @@ process SMOOTH_GENOPROBS {
   ${downsample_to_cov} \
   ${shuffle_bin_radius} \
   ${params.hap_block_cor_thresh} \
+  ${chr} \
   ${projectDir}/bin/quilt/get_hap_blocks.R
   """
 }

--- a/modules/quilt/smooth_genoprobs.nf
+++ b/modules/quilt/smooth_genoprobs.nf
@@ -1,0 +1,29 @@
+process SMOOTH_GENOPROBS {
+
+  cpus 1
+  memory {200.GB * task.attempt}
+  time {1.hour * task.attempt}
+  errorStrategy 'retry' 
+  maxRetries 1
+
+  container 'docker://sjwidmay/lcgbs_hr:latest'
+
+  publishDir "${params.pubdir}/${params.run_name}/${downsample_to_cov}/${shuffle_bin_radius}/geno_probs", pattern:"*_smooth.rds", mode:'copy', overwrite: true
+  
+  input:
+  tuple val(chrs), val(downsample_to_cov), val(shuffle_bin_radius), file(cross), file(geno_probs), file(allele_probs)
+
+  output:
+  tuple val(chrs), val(downsample_to_cov), val(shuffle_bin_radius), file("complete_cross_smooth.rds"), file("complete_genoprobs_smooth.rds"), file("complete_alleleprobs_smooth.rds"), emit: smooth_probs
+
+  script:
+
+  """
+  Rscript --vanilla ${projectDir}/bin/quilt/smooth_genoprobs.R ${geno_probs} \
+  ${cross} \
+  ${downsample_to_cov} \
+  ${shuffle_bin_radius} \
+  ${params.hap_block_cor_thresh} \
+  ${projectDir}/bin/quilt/get_hap_blocks.R
+  """
+}

--- a/nextflow.config
+++ b/nextflow.config
@@ -9,7 +9,7 @@ _____________________________________________________*/
 
 params {
     // Select workflow
-    workflow = 'stitch'
+    workflow = 'quilt'
 
     // select config from config folder to use
     config = "config/${params.workflow}.config"

--- a/workflows/quilt.nf
+++ b/workflows/quilt.nf
@@ -4,7 +4,6 @@ nextflow.enable.dsl=2
 // Nextflow pipeline for preparing lcWGS data for haplotype reconstruction using QUILT
 
 // Import modules
-include {help} from "${projectDir}/bin/help/wgs.nf"
 include {param_log} from "${projectDir}/bin/log/quilt.nf"
 include {getLibraryId} from "${projectDir}/bin/shared/getLibraryId.nf"
 include {CONCATENATE_READS_PE} from "${projectDir}/modules/utility_modules/concatenate_reads_PE"
@@ -19,7 +18,6 @@ include {PICARD_SORTSAM} from "${projectDir}/modules/picard/picard_sortsam"
 include {PICARD_MARKDUPLICATES} from "${projectDir}/modules/picard/picard_markduplicates"
 include {PICARD_COLLECTALIGNMENTSUMMARYMETRICS} from "${projectDir}/modules/picard/picard_collectalignmentsummarymetrics"
 include {PICARD_COLLECTWGSMETRICS} from "${projectDir}/modules/picard/picard_collectwgsmetrics"
-include {MPILEUP} from "${projectDir}/modules/bcftools/mpileup"
 include {SAMPLE_COVERAGE} from "${projectDir}/modules/samtools/calc_pileups"
 include {DOWNSAMPLE_BAM} from "${projectDir}/modules/samtools/downsample_bam"
 include {CREATE_BAMLIST} from "${projectDir}/modules/utility_modules/create_bamlist"
@@ -27,6 +25,7 @@ include {RUN_QUILT} from "${projectDir}/modules/quilt/run_quilt"
 include {QUILT_TO_QTL2} from "${projectDir}/modules/quilt/quilt_to_qtl2"
 include {GENOPROBS} from "${projectDir}/modules/quilt/genoprobs"
 include {CONCATENATE_GENOPROBS} from "${projectDir}/modules/quilt/concatenate_genoprobs"
+include {SMOOTH_GENOPROBS} from "${projectDir}/modules/quilt/smooth_genoprobs"
 
 // help if needed
 if (params.help){
@@ -181,9 +180,12 @@ if (params.library_type == 'ddRADseq'){
   // Reconstruct haplotypes with qtl2
   GENOPROBS(QUILT_TO_QTL2.out.qtl2files)
 
+  // Smooth genoprobs using haplotype block detection
+  //SMOOTH_GENOPROBS(GENOPROBS.out.geno_probs_out)
+
   // Concatenate chromosome-level genotype probs and generate whole-genome objects
-  collected_probs = GENOPROBS.out.geno_probs_out.groupTuple(by: [1,2])
-  CONCATENATE_GENOPROBS(collected_probs)
+  //collected_probs = SMOOTH_GENOPROBS.out.smooth_probs.groupTuple(by: [1,2])
+  //CONCATENATE_GENOPROBS(collected_probs)
 
   }
 }


### PR DESCRIPTION
Some changes in here are desirable:
- Running quilt in chunks with larger buffer
- Converting quilt vcfs to tab delimited format for more efficient qtl2 file creation
- In make_reference_data profile, enforcing an index be created after reference vcfs are generated is required for bcftools downstream

Some will be removed
- Interpolation results in noisier allele probs than grid anchoring